### PR TITLE
Add Command system

### DIFF
--- a/open_mafia_engine/api/__init__.py
+++ b/open_mafia_engine/api/__init__.py
@@ -9,3 +9,4 @@ Use as the following:
 from open_mafia_engine.core.all import *
 from open_mafia_engine.built_in.all import *
 from open_mafia_engine.builders.all import *
+from open_mafia_engine.commands.all import *

--- a/open_mafia_engine/builders/for_testing.py
+++ b/open_mafia_engine/builders/for_testing.py
@@ -9,7 +9,15 @@ def make_test_game(player_names: List[str], n_mafia: int = 1) -> Game:
     """Game builder for testing purposes.
 
     Always assigns mafia, then non-mafia, in player name order.
+    Must be at least 2 players (1 mafia, 1 town).
+
+    Parameters
+    ----------
+    n_mafia : int = 1
+        How many mafia players to add.
     """
+
+    n_mafia = int(n_mafia)
 
     n = len(player_names)
     assert isinstance(n_mafia, int)

--- a/open_mafia_engine/commands/all.py
+++ b/open_mafia_engine/commands/all.py
@@ -1,0 +1,14 @@
+"""All imports for commands."""
+
+# flake8: noqa
+import warnings as _w
+
+from .lobby import AbstractLobby
+from .parser import AbstractCommandParser, ShellCommandParser
+from .raw import RawCommand, TUser
+from .runner import CommandHandler, CommandRunner, command
+
+try:
+    from .pygment_lexer import MafiaLexer
+except ImportError:
+    _w.warn("Pygmants not installed, highlighting is not available.", ImportWarning)

--- a/open_mafia_engine/commands/all.py
+++ b/open_mafia_engine/commands/all.py
@@ -8,7 +8,11 @@ from .parser import AbstractCommandParser, ShellCommandParser
 from .raw import RawCommand, TUser
 from .runner import CommandHandler, CommandRunner, command
 
+PYGMENTS_AVAILABLE: bool
 try:
     from .pygment_lexer import MafiaLexer
+
+    PYGMENTS_AVAILABLE = True
 except ImportError:
     _w.warn("Pygmants not installed, highlighting is not available.", ImportWarning)
+    PYGMENTS_AVAILABLE = False

--- a/open_mafia_engine/commands/lobby.py
+++ b/open_mafia_engine/commands/lobby.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+
+from .raw import TUser
+
+__all__ = ["AbstractLobby", "SimpleLobby"]
+
+
+class AbstractLobby(Mapping, Generic[TUser]):
+    """A lobby, with mappings to user-defined objects.
+
+    Attributes
+    ----------
+    admins : dict
+        Mapping of admin names to user objects. Override this.
+    players : dict
+        Mapping of player names to user objects. Override this.
+    """
+
+    @property
+    @abstractmethod
+    def players(self) -> Dict[str, TUser]:
+        """Return mapping of str to players."""
+
+    @property
+    @abstractmethod
+    def admins(self) -> Dict[str, TUser]:
+        """Return mapping of str to admins."""
+
+    @abstractmethod
+    def add_player(self, name: str, user: TUser):
+        """Add the player to the game."""
+
+    @abstractmethod
+    def add_admin(self, name: str, user: TUser):
+        """Add the player to the game."""
+
+    @property
+    def player_names(self) -> List[str]:
+        return list(self.players.keys())
+
+    @property
+    def admin_names(self) -> List[str]:
+        return list(self.admins.keys())
+
+    @property
+    def all_names(self) -> List[str]:
+        return list(set(self.player_names).union(self.admin_names))
+
+    def __getitem__(self, k: str) -> TUser:
+        res = self.admins.get(k, None)
+        if res is None:
+            res = self.players.get(k, None)
+        if res is None:
+            raise KeyError(k)
+        return res
+
+    def __iter__(self):
+        keys = set(self.all_names)
+        return iter(keys)
+
+    def __len__(self):
+        keys = set(self.all_names)
+        return len(keys)
+
+
+class SimpleLobby(AbstractLobby[TUser]):
+    """Simple lobby implementation."""
+
+    def __init__(
+        self,
+        admins: Dict[str, TUser] = None,
+        players: Dict[str, TUser] = None,
+    ) -> None:
+        if admins is None:
+            admins = {}
+        if players is None:
+            players = {}
+        self._admins = dict(admins)
+        self._players = dict(players)
+
+    @property
+    def players(self) -> Dict[str, TUser]:
+        return dict(self._players)
+
+    @property
+    def admins(self) -> Dict[str, TUser]:
+        return dict(self._admins)
+
+    def add_admin(self, name: str, user: TUser):
+        self._admins[name] = user
+
+    def add_player(self, name: str, user: TUser):
+        self._players[name] = user

--- a/open_mafia_engine/commands/parser.py
+++ b/open_mafia_engine/commands/parser.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+import shlex
+from abc import ABC, abstractmethod
+from typing import List
+
+from .raw import RawCommand
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AbstractCommandParser", "ShellCommandParser"]
+
+
+class AbstractCommandParser(ABC):
+    """Base for command parsers."""
+
+    @abstractmethod
+    def parse(self, source: str, obj: str) -> List[RawCommand]:
+        """Parses `obj` into zero, one or more `RawCommand` objects."""
+        return []
+
+
+class ShellCommandParser(AbstractCommandParser):
+    """Implementation for shell-like command parsing."""
+
+    def parse(self, source: str, obj: str) -> List[RawCommand]:
+        if not isinstance(obj, str):
+            # raise TypeError(f"Expected str, got {obj!r}")
+            logger.warning(f"Cannot parse object, ignoring: {obj!r}")
+            return []
+
+        text = obj
+        # TODO: keyword and flag arguments? Not just positional :)
+        raw = shlex.split(text, posix=True)
+        res = RawCommand(source, raw[0], args=tuple(raw[1:]))
+        return [res]
+
+
+if __name__ == "__main__":
+    # For testing
+    sp = ShellCommandParser()

--- a/open_mafia_engine/commands/pygment_lexer.py
+++ b/open_mafia_engine/commands/pygment_lexer.py
@@ -1,0 +1,33 @@
+"""Optional Pygments lexer for the Mafia 'shell'-style language."""
+
+from pygments.lexer import RegexLexer
+from pygments.token import *
+
+__all__ = ["MafiaLexer"]
+
+
+class MafiaLexer(RegexLexer):
+    """Custom Pygments lexer for mafia commands."""
+
+    name = "Mafia"
+    aliases = ["mafia"]
+    filenames = []
+
+    tokens = {
+        "root": [
+            (R"\b^[\w'-]+\b", Keyword),
+            (R"/\*", Keyword.Pseudo, "comment"),
+            (R"\"", Name.Variable, "complexquote"),
+            (R"\s", Text),
+        ],
+        "complexquote": [
+            (R"\"", Name.Variable, "#pop"),
+            (R"\S", Name.Variable),
+        ],
+        "comment": [
+            (R"[^*/]", Keyword.Pseudo),
+            (R"/\*", Keyword.Pseudo, "#push"),
+            (R"\*/", Keyword.Pseudo, "#pop"),
+            (R"[*/]", Keyword.Pseudo),
+        ],
+    }

--- a/open_mafia_engine/commands/raw.py
+++ b/open_mafia_engine/commands/raw.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple, TypeVar
+
+__all__ = ["TUser", "RawCommand"]
+
+TUser = TypeVar("TUser")  # User type in your application
+
+
+@dataclass(frozen=True)
+class RawCommand:
+    """Raw parsed command"""
+
+    source: str
+    name: str
+    args: Tuple = tuple()
+    kwargs: Dict[str, Any] = field(default_factory=dict)

--- a/open_mafia_engine/commands/runner.py
+++ b/open_mafia_engine/commands/runner.py
@@ -1,25 +1,15 @@
 from __future__ import annotations
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Type, Union
 
 from makefun import partial
 
-from open_mafia_engine.core.all import Game
+from open_mafia_engine.core.all import ABILITY, EActivate, Game, GameBuilder, get_path
 from open_mafia_engine.util.matcher import FuzzyMatcher
 
 from .lobby import AbstractLobby, SimpleLobby
-from .parser import AbstractCommandParser
-from .raw import TUser, RawCommand
+from .parser import AbstractCommandParser, ShellCommandParser
+from .raw import RawCommand, TUser
 
 __all__ = ["command", "CommandHandler", "CommandRunner"]
 
@@ -122,32 +112,65 @@ def command(
 
 
 class CommandRunner(Generic[TUser]):
-    """Runs the most important commands.
+    """Interprets and runs commands on the Mafia engine.
 
-    TODO: Docstring.
+    This handles both pre-game commands (such as joining or starting the game)
+    and commands during the game.
+    Basic Mafia commands are already added.
+
+    To add or override a command handler, use the `command` decorator:
+
+        class MyRunner(CommandRunner[MyUserType]):
+            @command("blah", game=True)
+            def my_blah(self, source: str, *args, **kwargs):
+                return
+
+    Attributes
+    ----------
+    parser : AbstractCommandParser
+        Your own parser implementation, or ShellCommandParser() by default.
+    lobby : AbstractLobby
+        Your own lobby implementation, or SimpleLobby[TUser]() by default.
+    game : None or Game
+        The game state. Defaults to None.
+    score_cutoff : int
+
     """
 
     registered_commands: Dict[str, CommandHandler]
 
     def __init__(
         self,
-        parser: AbstractCommandParser,
-        lobby: AbstractLobby[TUser] = SimpleLobby(),
+        parser: AbstractCommandParser = ShellCommandParser(),
+        lobby: AbstractLobby[TUser] = SimpleLobby[TUser](),
         game: Optional[Game] = None,
         *,
         score_cutoff: int = 80,
     ):
         self.parser = parser
         self.lobby = lobby
-        self.game = game
         self.score_cutoff = int(score_cutoff)
+        # This will check :)
+        self.game = game
+
+    @property
+    def game(self) -> Optional[Game]:
+        return self._game
+
+    @game.setter
+    def game(self, game: Optional[Game]):
+        if game is not None and not isinstance(game, Game):
+            raise TypeError(f"Expected None or Game, got {game!r}")
+        self._game = game
 
     @property
     def in_game(self) -> bool:
-        return self.game is not None
+        """True if the game is active."""
+        return self._game is not None
 
     @property
     def in_lobby(self) -> bool:
+        """True if the game is not active."""
         return not self.in_game
 
     def parse_and_run(self, source: str, obj: str) -> List[Tuple[RawCommand, Any]]:
@@ -168,7 +191,10 @@ class CommandRunner(Generic[TUser]):
         return matcher[name]
 
     def dispatch(self, rc: RawCommand) -> Any:
-        """Calls the relevant command given by `rc`."""
+        """Calls the relevant command given by `rc`.
+
+        TODO: Backup handler for in-game and in-lobby handlers.
+        """
         ch: CommandHandler = self.find_command(rc.name)
         if ch.admin:
             if rc.source not in self.lobby.admin_names:
@@ -177,6 +203,8 @@ class CommandRunner(Generic[TUser]):
             raise RuntimeError(f"Command {ch.name!r} not available in lobby.")
         if self.in_game and not ch.game:
             raise RuntimeError(f"Command {ch.name!r} not available during game.")
+
+        # TODO: Possibly add debug output here?
         return ch.func(self, rc.source, *rc.args, **rc.kwargs)
 
     def user_for(self, name: str) -> Optional[TUser]:
@@ -191,45 +219,75 @@ class CommandRunner(Generic[TUser]):
             raise ValueError(f"No user found for {source!r}. Possibly not implemented?")
         self.lobby.add_player(source, user)  # [source] = user
 
-    @command("force-join", admin=True, lobby=True)
-    def force_join(self, source: str, *args, **kwargs):
-        """Force a user to join the lobby.
+    @command("in", lobby=True)
+    def _join2(self, source: str):
+        """Alias for 'join'."""
+        return self.join(source)
 
-        TODO: Implement!
-        """
+    @command("force-join", admin=True, lobby=True)
+    def force_join(self, source: str, *targets: List[str]):
+        """Force one or more users to join the lobby."""
+        users: Dict[str, TUser] = {}
+        errors: List[str] = []
+        for t in targets:
+            user = self.user_for(t)
+            if user is None:
+                errors.append(t)
+            else:
+                users[t] = user
+        if len(errors) > 0:
+            raise ValueError(f"No users found for these names: {errors!r}.")
+        for n, u in users.items():
+            self.lobby.add_player(n, u)
 
     @command("kick", admin=True, lobby=True, game=True)
     def kick(self, source: str, *args, **kwargs):
         """Kick a player from the lobby or game.
 
         TODO: Implement!
+        Will probably need change in AbstractLobby.
+        Will definitely need change in Game to handle kicking/modkilling...
         """
 
-    @command("in", lobby=True)
-    def join2(self, source: str):
-        """Alias for 'join'."""
-        return self.join(source)
-
     @command("create-game", admin=True, lobby=True)
-    def create_game(self, source: str, *args, **kwargs):
+    def create_game(self, source: str, builder_name: str, *args, **kwargs):
         """Creates the game.
 
         TODO: Implement!
         """
+        if self.in_game:
+            raise ValueError("BUG. Currently in a game - can't create one.")
+        builder = GameBuilder.load(builder_name)
+        game = builder.build(player_names=self.lobby.player_names, *args, **kwargs)
+        self.game = game
+
+    @command("destroy-game", admin=True, game=True)
+    def destroy_game(self, source: str):
+        """Stops the game immediately.
+
+        Do we even need this? I assume you'd just make a new runner... :)
+
+        TODO: Maybe a bit more elegantly?...
+        TODO: Auto-stop the game when GameEnder works?
+        """
+        self.game = None
 
     @command("phase", admin=True, game=True)
-    def change_phase(self, source: str, *args, **kwargs):
-        """Changes the phase (admin action).
-
-        TODO: Implement!
-        """
+    def change_phase(self, source: str, new_phase: Optional[str] = None):
+        """Changes the phase (admin action)."""
+        if self.game is None:
+            raise RuntimeError("Game not yet started.")
+        self.game.change_phase(new_phase=new_phase)
+        # Alternatively:
+        # e = ETryPhaseChange(self.game, new_phase=new_phase)
+        # self.game.process_event(e)
 
     @command("do", game=True)
-    def do(self, source: str, cmd: str, *args, **kwargs):
-        """Activates an ability.
-
-        TODO: Implement!
-        """
+    def do(self, source: str, abil_name: str, *args, **kwargs):
+        """Activates an ability."""
+        abil_path = get_path(source, ABILITY, abil_name)
+        e = EActivate(self.game, abil_path, *args, **kwargs)
+        self.game.process_event(e)
 
     @command("vote", game=True)
     def vote(self, source: str, *args, **kwargs):
@@ -242,3 +300,5 @@ class CommandRunner(Generic[TUser]):
         # TODO: 'vote' for "unvote-all" or smth?
         # TODO: Maybe add this only in ForumCommandRunner?
         return self.do(source, "vote", *args, **kwargs)
+
+    # TODO: Maybe allow backup command handlers for unknown commands? :)

--- a/open_mafia_engine/commands/runner.py
+++ b/open_mafia_engine/commands/runner.py
@@ -121,9 +121,13 @@ class CommandRunner(Generic[TUser]):
     To add or override a command handler, use the `command` decorator:
 
         class MyRunner(CommandRunner[MyUserType]):
-            @command("blah", game=True)
-            def my_blah(self, source: str, *args, **kwargs):
+            @command("foo", game=True)
+            def my_foo(self, source: str, *args, **kwargs):
                 return
+
+    The command decorator defaults to non-admin, in-game actions.
+    Specifying `lobby=True` will, by default, allow only lobby use.
+    If you want it always on, use `@command("name", game=True, lobby=True)`
 
     Attributes
     ----------
@@ -134,7 +138,8 @@ class CommandRunner(Generic[TUser]):
     game : None or Game
         The game state. Defaults to None.
     score_cutoff : int
-
+        The score cutoff for matching command names, from 0 to 100.
+        Default is 80 (relatively strict).
     """
 
     registered_commands: Dict[str, CommandHandler]
@@ -248,12 +253,13 @@ class CommandRunner(Generic[TUser]):
         Will probably need change in AbstractLobby.
         Will definitely need change in Game to handle kicking/modkilling...
         """
+        # TODO: Implement.
 
     @command("create-game", admin=True, lobby=True)
     def create_game(self, source: str, builder_name: str, *args, **kwargs):
         """Creates the game.
 
-        TODO: Implement!
+        TODO: Need to standardize builder options.
         """
         if self.in_game:
             raise ValueError("BUG. Currently in a game - can't create one.")
@@ -268,7 +274,7 @@ class CommandRunner(Generic[TUser]):
         Do we even need this? I assume you'd just make a new runner... :)
 
         TODO: Maybe a bit more elegantly?...
-        TODO: Auto-stop the game when GameEnder works?
+        TODO: Auto-stop the game when EGameEnded occurs? Not sure how that would work.
         """
         self.game = None
 

--- a/open_mafia_engine/commands/runner.py
+++ b/open_mafia_engine/commands/runner.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+
+from makefun import partial
+
+from open_mafia_engine.core.all import Game
+from open_mafia_engine.util.matcher import FuzzyMatcher
+
+from .lobby import AbstractLobby, SimpleLobby
+from .parser import AbstractCommandParser
+from .raw import TUser, RawCommand
+
+__all__ = ["command", "CommandHandler", "CommandRunner"]
+
+
+class CommandHandler(object):
+    """Descriptor, wrapper for command functions.
+
+    Parameters
+    ----------
+    func : Callable
+        The wrapped function.
+    game : bool
+        If True, allows use during the game. Default is True.
+    lobby : bool
+        If True, allows use in the lobby. Default is False.
+    admin : bool
+        If True, this is an admin-only command.
+    name : None or str
+        Command name. If None (default), uses function's name.
+    """
+
+    registered: Dict[str, CommandHandler] = {}
+    score_cutoff: int = 80
+
+    def __init__(
+        self,
+        func: Callable,
+        *,
+        game: bool = True,
+        lobby: bool = False,
+        admin: bool = False,
+        name: str = None,
+    ):
+        if not callable(func):
+            raise TypeError(f"`func` must be callable, got {func!r}")
+        if name is None:
+            name = func.__name__
+        # TODO: Get documentation :)
+
+        self.func = func
+        self.name = name
+        self.game = bool(game)
+        self.lobby = bool(lobby)
+        self.admin = bool(admin)
+
+    def __set_name__(self, owner: Type[CommandRunner], name: str):
+        self.bound_name = name
+        _RC = "registered_commands"
+
+        # self.registered[name] = self  # FIXME: change to the following?
+
+        # Create a dict for `owner`
+        if not hasattr(owner, _RC):
+            v = dict(**getattr(super(owner), _RC, {}))
+            setattr(owner, _RC, v)
+        owner.registered_commands[name] = self
+
+    def __get__(self, obj: CommandRunner, objtype=None):
+        return partial(self.func, obj)
+
+
+def command(
+    name_or_func: Union[str, Callable],
+    *,
+    game: bool = None,
+    lobby: bool = None,
+    admin: bool = False,
+) -> Union[Callable]:
+    """Decorator to register methods as commands.
+
+    By default, "game" is True, "lobby" is `not game`, and "admin" is False.
+    """
+
+    if game is None:
+        if lobby is None:
+            game = True
+            lobby = False
+        else:
+            game = not lobby
+    else:
+        if lobby is None:
+            lobby = not game
+    game = bool(game)
+    lobby = bool(lobby)
+    admin = bool(admin)
+
+    if isinstance(name_or_func, str):
+
+        def inner(func: Callable) -> CommandHandler:
+            return CommandHandler(
+                func, name=name_or_func, game=game, lobby=lobby, admin=admin
+            )
+
+        return inner
+    elif callable(name_or_func):
+        func = name_or_func
+        return CommandHandler(func, game=game, lobby=lobby, admin=admin)
+    else:
+        raise TypeError(f"Argument to `command` is neither str, nor callable.")
+
+
+class CommandRunner(Generic[TUser]):
+    """Runs the most important commands.
+
+    TODO: Docstring.
+    """
+
+    registered_commands: Dict[str, CommandHandler]
+
+    def __init__(
+        self,
+        parser: AbstractCommandParser,
+        lobby: AbstractLobby[TUser] = SimpleLobby(),
+        game: Optional[Game] = None,
+        *,
+        score_cutoff: int = 80,
+    ):
+        self.parser = parser
+        self.lobby = lobby
+        self.game = game
+        self.score_cutoff = int(score_cutoff)
+
+    @property
+    def in_game(self) -> bool:
+        return self.game is not None
+
+    @property
+    def in_lobby(self) -> bool:
+        return not self.in_game
+
+    def parse_and_run(self, source: str, obj: str) -> List[Tuple[RawCommand, Any]]:
+        """Parses commands and runs them."""
+        rcs = self.parser.parse(source, obj)
+        res = []
+        for rc in rcs:
+            out_i = self.dispatch(rc)
+            res.append((rcs, out_i))
+        return res
+
+    def find_command(self, name: str) -> CommandHandler:
+        """Finds the closes command handler."""
+        matcher = FuzzyMatcher(
+            choices=self.registered_commands,
+            score_cutoff=self.score_cutoff,
+        )
+        return matcher[name]
+
+    def dispatch(self, rc: RawCommand) -> Any:
+        """Calls the relevant command given by `rc`."""
+        ch: CommandHandler = self.find_command(rc.name)
+        if ch.admin:
+            if rc.source not in self.lobby.admin_names:
+                raise RuntimeError(f"Command {ch.name!r} requires admin privileges.")
+        if self.in_lobby and not ch.lobby:
+            raise RuntimeError(f"Command {ch.name!r} not available in lobby.")
+        if self.in_game and not ch.game:
+            raise RuntimeError(f"Command {ch.name!r} not available during game.")
+        return ch.func(self, rc.source, *rc.args, **rc.kwargs)
+
+    def user_for(self, name: str) -> Optional[TUser]:
+        """Gets the user by name from the lobby."""
+        return self.lobby.get(name, None)
+
+    @command("join", lobby=True)
+    def join(self, source: str):
+        """Joins the game as a player."""
+        user = self.user_for(source)
+        if user is None:
+            raise ValueError(f"No user found for {source!r}. Possibly not implemented?")
+        self.lobby.add_player(source, user)  # [source] = user
+
+    @command("force-join", admin=True, lobby=True)
+    def force_join(self, source: str, *args, **kwargs):
+        """Force a user to join the lobby.
+
+        TODO: Implement!
+        """
+
+    @command("kick", admin=True, lobby=True, game=True)
+    def kick(self, source: str, *args, **kwargs):
+        """Kick a player from the lobby or game.
+
+        TODO: Implement!
+        """
+
+    @command("in", lobby=True)
+    def join2(self, source: str):
+        """Alias for 'join'."""
+        return self.join(source)
+
+    @command("create-game", admin=True, lobby=True)
+    def create_game(self, source: str, *args, **kwargs):
+        """Creates the game.
+
+        TODO: Implement!
+        """
+
+    @command("phase", admin=True, game=True)
+    def change_phase(self, source: str, *args, **kwargs):
+        """Changes the phase (admin action).
+
+        TODO: Implement!
+        """
+
+    @command("do", game=True)
+    def do(self, source: str, cmd: str, *args, **kwargs):
+        """Activates an ability.
+
+        TODO: Implement!
+        """
+
+    @command("vote", game=True)
+    def vote(self, source: str, *args, **kwargs):
+        """Votes for the target(s)."""
+        return self.do(source, "vote", *args, **kwargs)
+
+    @command("unvote", game=True)
+    def unvote(self, source: str, *args, **kwargs):
+        """Unvotes from all previous votes."""
+        # TODO: 'vote' for "unvote-all" or smth?
+        # TODO: Maybe add this only in ForumCommandRunner?
+        return self.do(source, "vote", *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ python = "^3.8"
 pydantic = "^1.7.3"
 pydantic-yaml = "^0.2.3"
 sortedcontainers = "^2.3.0"
+makefun = "^1.11.3"
+fuzzywuzzy = "^0.18.0"
+cloudpickle = "^1.6.0"
 mkdocs = { version = "^1.1.2", optional = true }
 beautifulsoup4 = { version = "^4.9.3", optional = true }
 requests = { version = "^2.25.1", optional = true }
@@ -30,9 +33,7 @@ requests = { version = "^2.25.1", optional = true }
 flake8 = { version = "^3.9.2", optional = true }
 mypy = { version = "^0.800", optional = true }
 pytest = { version = "^6.2.4", optional = true }
-makefun = "^1.11.3"
-fuzzywuzzy = "^0.18.0"
-cloudpickle = "^1.6.0"
+pygments = { version = "^2.9.0", optional = true }
 
 [tool.poetry.extras]
 bay12 = ["beautifulsoup4", "requests"]
@@ -40,6 +41,7 @@ docs = ["mkdocs"]
 ruamel = ["ruamel.yaml"]
 dev = ["flake8", "mypy", "pytest"]
 test = ["pytest"]
+pygments = ["pygments"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"


### PR DESCRIPTION
Added a "command system" to allow command-based interaction from multiple users.

The default `CommandRunner` uses a `ShellCommandParser` and `SimpleLobby`, but you can define your own parsers and lobbies.
You can also add more commands to your CommandRunner.